### PR TITLE
KBZ-4735 limit the data exposed on errors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,10 +8,10 @@ A Rack compatible, documenting JSON-RPC 2 DSL/server implementation for ruby.
   Fix the regression introduced in 0.1.1 which makes the valid requests crash
   Stop exposing application internals publicly on errors
 
-* 0.1.1 - 4-Jan-2013
+* 0.1.1 - 4-Jan-2014
   Improve logging of exceptions / failure
 
-* 0.1.0 - 4-Jan-2013
+* 0.1.0 - 4-Jan-2014
   Turn on timing & logging of all requests
 
 * 0.0.9 - 3-Sep-2012

--- a/README.markdown
+++ b/README.markdown
@@ -6,6 +6,7 @@ A Rack compatible, documenting JSON-RPC 2 DSL/server implementation for ruby.
 
 * UNRELEASED
   Fix the regression introduced in 0.1.1 which makes the valid requests crash
+  Stop exposing application internals publicly on errors
 
 * 0.1.1 - 4-Jan-2013
   Improve logging of exceptions / failure

--- a/jsonrpc2.gemspec
+++ b/jsonrpc2.gemspec
@@ -43,7 +43,7 @@ e.g.
 
 EOD
   gem.summary       = %q{JSON-RPC2 server DSL}
-  gem.homepage      = "http://github.com/geoffyoungs/jsonrpc2"
+  gem.homepage      = "http://github.com/livelink/jsonrpc2"
 
   gem.executables   = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")

--- a/lib/jsonrpc2/interface.rb
+++ b/lib/jsonrpc2/interface.rb
@@ -214,14 +214,14 @@ module JSONRPC2
 
         call(rpc['method'], rpc['id'], rpc['params'])
       rescue AuthFail => e
-        response_error(-32000, "AuthFail: #{e.class}: #{e.message}", {}) # XXX: Change me
+        response_error(-32000, 'AuthFail: Invalid credentials', {})
       rescue APIFail => e
-        response_error(-32000, "APIFail: #{e.class}: #{e.message}", {}) # XXX: Change me
+        response_error(-32000, 'APIFail', {})
       rescue KnownError => e
-        response_error(e.code, e.message, e.data) # XXX: Change me
+        response_error(e.code, 'An error occurred', {})
       rescue Exception => e
         logger.error("#{env['json.request-id']} Internal error calling #{rpc.inspect} - #{e.class}: #{e.message} #{e.backtrace.join("\n    ")}") if logger.respond_to?(:error)
-        response_error(-32000, "#{e.class}: #{e.message}", e.backtrace) # XXX: Change me
+        response_error(-32000, "An error occurred. Check logs for details", {})
       end
     end
 

--- a/lib/jsonrpc2/interface.rb
+++ b/lib/jsonrpc2/interface.rb
@@ -252,11 +252,7 @@ module JSONRPC2
           result = send(method, params)
         end
 
-        begin
-          Types.valid_result?(self.class, method, result)
-        rescue Exception => e
-          return response_error(-32602, "Invalid result - #{e.message}", {})
-        end
+        Types.valid_result?(self.class, method, result)
 
         response_ok(id, result)
       else

--- a/lib/jsonrpc2/interface.rb
+++ b/lib/jsonrpc2/interface.rb
@@ -242,7 +242,7 @@ module JSONRPC2
       if api_methods.include?(method)
         begin
           Types.valid_params?(self.class, method, params)
-        rescue Exception => e
+        rescue Types::InvalidParamsError => e
           return response_error(-32602, "Invalid params - #{e.message}", {})
         end
 

--- a/lib/jsonrpc2/types.rb
+++ b/lib/jsonrpc2/types.rb
@@ -17,6 +17,7 @@ module JSONRPC2
   # * CustomType - A defined custom object type
   module Types
     class InvalidParamsError < ArgumentError; end
+    class InvalidResultError < RuntimeError; end
 
     module_function
     DateTimeRegex = %r"([0-9]{4})(-([0-9]{2})(-([0-9]{2})(T([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?"
@@ -127,8 +128,11 @@ module JSONRPC2
       if about[:returns].nil?
         return value.nil?
       end
-      valid?(interface, about[:returns][:type], value) or
-        raise "Invalid return type: should have been #{about[:returns][:type]}, was #{value.class.name}"
+      return true if valid?(interface, about[:returns][:type], value)
+
+      raise InvalidResultError, <<~MSG.chomp
+        Invalid return type: should have been #{about[:returns][:type]}, was #{value.class.name}
+      MSG
     end
   end
 

--- a/lib/jsonrpc2/types.rb
+++ b/lib/jsonrpc2/types.rb
@@ -125,9 +125,7 @@ module JSONRPC2
     def valid_result?(interface, method, value)
       about = interface.about[method.to_s]
       return true if about.nil? # Undefined
-      if about[:returns].nil?
-        return value.nil?
-      end
+      return value.nil? if about[:returns].nil?
       return true if valid?(interface, about[:returns][:type], value)
 
       raise InvalidResultError, <<~MSG.chomp

--- a/lib/jsonrpc2/types.rb
+++ b/lib/jsonrpc2/types.rb
@@ -16,6 +16,8 @@ module JSONRPC2
   # * Value (or Any or void) - Any value of any type
   # * CustomType - A defined custom object type
   module Types
+    class InvalidParamsError < ArgumentError; end
+
     module_function
     DateTimeRegex = %r"([0-9]{4})(-([0-9]{2})(-([0-9]{2})(T([0-9]{2}):([0-9]{2})(:([0-9]{2})(\.([0-9]+))?)?(Z|(([-+])([0-9]{2}):([0-9]{2})))?)?)?)?"
     DateRegex     = %r'\A\d{4}-\d{2}-\d{2}\z'
@@ -76,7 +78,7 @@ module JSONRPC2
     end
 
     # Checks that param hash is valid for API call
-    # 
+    #
     # @param [Interface] interface API class
     # @param [String] method Method name
     # @param [Hash] data params hash to check
@@ -92,23 +94,23 @@ module JSONRPC2
         return true
       end
 
-      raise "Params should not be nil" if data.nil?
+      raise InvalidParamsError, "Params should not be nil" if data.nil?
 
       extra_keys = data.keys - param_names
       unless extra_keys.empty?
-        raise "Extra parameters #{extra_keys.inspect} for #{method}."
+        raise InvalidParamsError, "Extra parameters #{extra_keys.inspect} for #{method}."
       end
 
       params.each do |param|
         if data.has_key?(param[:name])
           value = data[param[:name].to_s]
           unless valid?(interface, param[:type], value)
-            raise "'#{param[:name]}' should be of type #{param[:type]}, was #{value.class.name}"
+            raise InvalidParamsError, "'#{param[:name]}' should be of type #{param[:type]}, was #{value.class.name}"
           end
         elsif ! param[:required]
           next true
         else
-          raise "Missing parameter: '#{param[:name]}' of type #{param[:type]} for #{method}"
+          raise InvalidParamsError, "Missing parameter: '#{param[:name]}' of type #{param[:type]} for #{method}"
         end
       end
     end

--- a/spec/lib/interface_spec.rb
+++ b/spec/lib/interface_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe JSONRPC2::Interface do
       it 'informs about the server error' do
         expect(parsed_response_body[:error]).to match(
           code: -32000,
-          message: 'RuntimeError: He-Must-Not-Be-Named', # Bad - exposes class and private error message
-          data: a_kind_of(Array)                         # Bad - exposes stacktrace
+          message: 'An error occurred. Check logs for details',
+          data: {}
         )
       end
     end

--- a/spec/lib/interface_spec.rb
+++ b/spec/lib/interface_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe JSONRPC2::Interface do
       result 'String', 'A tailored greeting'
       def hello
         raise 'He-Must-Not-Be-Named' if params['name'] == 'Voldemort'
+        return 42 if params['name'] == 'Marvin'
+
         "Hello, #{params['name']}!"
       end
     end
@@ -99,6 +101,18 @@ RSpec.describe JSONRPC2::Interface do
           expect(parsed_response_body[:error]).to eq(
             code: -32602,
             message: 'Invalid params - Extra parameters ["extra"] for hello.',
+            data: {}
+          )
+        end
+      end
+
+      context 'with an invalid result type' do
+        let(:params) { { 'name' => 'Marvin' } }
+
+        it 'returns the helpful error' do
+          expect(parsed_response_body[:error]).to eq(
+            code: -32602,
+            message: 'Invalid result - Invalid return type: should have been String, was Integer',
             data: {}
           )
         end

--- a/spec/lib/interface_spec.rb
+++ b/spec/lib/interface_spec.rb
@@ -85,10 +85,23 @@ RSpec.describe JSONRPC2::Interface do
     end
 
     context 'with a valid param' do
-      let(:rpc_request_data) { super().merge('params' => { 'name' => 'Geoff' }) }
+      let(:rpc_request_data) { super().merge('params' => params) }
+      let(:params) { { 'name' => 'Geoff' } }
 
       it 'returns the valid response' do
         expect(parsed_response_body[:result]).to eq('Hello, Geoff!')
+      end
+
+      context 'with an extra param' do
+        let(:params) { super().merge('extra' => 'I should not be here') }
+
+        it 'returns the helpful param error' do
+          expect(parsed_response_body[:error]).to eq(
+            code: -32602,
+            message: 'Invalid params - Extra parameters ["extra"] for hello.',
+            data: {}
+          )
+        end
       end
     end
 

--- a/spec/lib/interface_spec.rb
+++ b/spec/lib/interface_spec.rb
@@ -109,10 +109,10 @@ RSpec.describe JSONRPC2::Interface do
       context 'with an invalid result type' do
         let(:params) { { 'name' => 'Marvin' } }
 
-        it 'returns the helpful error' do
-          expect(parsed_response_body[:error]).to eq(
-            code: -32602,
-            message: 'Invalid result - Invalid return type: should have been String, was Integer',
+        it 'informs about the server error' do
+          expect(parsed_response_body[:error]).to match(
+            code: -32000,
+            message: 'An error occurred. Check logs for details',
             data: {}
           )
         end


### PR DESCRIPTION
## Problem
Some errors are reported with the class name, error message and/or backtrace, creating a vulnerability

## Solution
- Create a dedicated type for param errors, so that it can be intercepted separately without hacks
- Limit the data exposed by errors

## Notes
On the occasion I fixed a typo in changelog and updated gem's homepage