### PR TITLE
Bump version and tidy up the metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+* UNRELEASED
+  Fix the regression introduced in 0.1.1 which makes the valid requests crash
+  Stop exposing application internals publicly on errors
+  Make it possible to define callback for server errors with `JSONRPC2::Interface#on_server_error`
+
+* 0.1.1 - 4-Jan-2014
+  Improve logging of exceptions / failure
+
+* 0.1.0 - 4-Jan-2014
+  Turn on timing & logging of all requests
+
+* 0.0.9 - 3-Sep-2012
+  Improve client validation
+  Make params optional in request call
+
+* 0.0.8 - 3-Sep-2012
+  Add #request to access Rack::Request object
+  Make URLs in HTML interface clickable
+
+* 0.0.7 - 27-Aug-2012
+  Add bundled Bootstrap assets for HTML test interface
+
+* 0.0.6 - 24-Aug-2012
+  Add Date/Time/DateTime as special string types with regex checks for validation
+
+* 0.0.5 - 19-Jul-2012
+  Add commandline client jsonrpc2
+  Add #auth to access currently authenticated username

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,38 @@
-* UNRELEASED
-  Fix the regression introduced in 0.1.1 which makes the valid requests crash
-  Stop exposing application internals publicly on errors
-  Make it possible to define callback for server errors with `JSONRPC2::Interface#on_server_error`
+## UNRELEASED
+### Added
+- Possibility to define callback for server errors with `JSONRPC2::Interface#on_server_error`
 
-* 0.1.1 - 4-Jan-2014
-  Improve logging of exceptions / failure
+### Fixed
+- Fixed regression introduced in 0.1.1 which makes the valid requests crash
+- Stopped exposing application internals publicly on errors
 
-* 0.1.0 - 4-Jan-2014
-  Turn on timing & logging of all requests
+## [0.1.1] - 2014-01-04
+### Changed
+- Improve logging of exceptions / failure
 
-* 0.0.9 - 3-Sep-2012
-  Improve client validation
-  Make params optional in request call
+## [0.1.0] - 2014-01-04
+### Changed
+- Turn on timing & logging of all requests
 
-* 0.0.8 - 3-Sep-2012
-  Add #request to access Rack::Request object
-  Make URLs in HTML interface clickable
+## [0.0.9] - 2012-09-03
+### Changed
+- Improve client validation
+- Make params optional in request call
 
-* 0.0.7 - 27-Aug-2012
-  Add bundled Bootstrap assets for HTML test interface
+## [0.0.8] - 2012-09-03
+### Changed
+- Add #request to access Rack::Request object
+- Make URLs in HTML interface clickable
 
-* 0.0.6 - 24-Aug-2012
-  Add Date/Time/DateTime as special string types with regex checks for validation
+## [0.0.7] - 2012-08-27
+### Changed
+- Add bundled Bootstrap assets for HTML test interface
 
-* 0.0.5 - 19-Jul-2012
-  Add commandline client jsonrpc2
-  Add #auth to access currently authenticated username
+## [0.0.6] - 2012-08-24
+### Changed
+- Add Date/Time/DateTime as special string types with regex checks for validation
+
+## [0.0.5] - 2012-07-19
+### Changed
+- Add commandline client jsonrpc2
+- Add #auth to access currently authenticated username

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## UNRELEASED
+## [0.2.0] - 2022-04-07
 ### Added
 - Possibility to define callback for server errors with `JSONRPC2::Interface#on_server_error`
 

--- a/README.markdown
+++ b/README.markdown
@@ -2,37 +2,6 @@
 
 A Rack compatible, documenting JSON-RPC 2 DSL/server implementation for ruby.
 
-## Changes
-
-* UNRELEASED
-  Fix the regression introduced in 0.1.1 which makes the valid requests crash
-  Stop exposing application internals publicly on errors
-  Make it possible to define callback for server errors with `JSONRPC2::Interface#on_server_error`
-
-* 0.1.1 - 4-Jan-2014
-  Improve logging of exceptions / failure
-
-* 0.1.0 - 4-Jan-2014
-  Turn on timing & logging of all requests
-
-* 0.0.9 - 3-Sep-2012
-  Improve client validation
-  Make params optional in request call
-
-* 0.0.8 - 3-Sep-2012
-  Add #request to access Rack::Request object
-  Make URLs in HTML interface clickable
-
-* 0.0.7 - 27-Aug-2012
-  Add bundled Bootstrap assets for HTML test interface
-
-* 0.0.6 - 24-Aug-2012
-  Add Date/Time/DateTime as special string types with regex checks for validation
-
-* 0.0.5 - 19-Jul-2012
-  Add commandline client jsonrpc2
-  Add #auth to access currently authenticated username
-
 ## Features
 
 * Inline documentation

--- a/jsonrpc2.gemspec
+++ b/jsonrpc2.gemspec
@@ -51,6 +51,12 @@ EOD
   gem.name          = "jsonrpc2"
   gem.require_paths = ["lib"]
   gem.version       = JSONRPC2::VERSION
+  gem.metadata = {
+    "bug_tracker_uri"   => "https://github.com/livelink/jsonrpc2/issues",
+    "changelog_uri"     => "https://github.com/livelink/jsonrpc2/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://github.com/livelink/jsonrpc2#inline-documentation",
+  }
+
   gem.add_dependency("httpclient")
   gem.add_dependency("json")
   gem.add_dependency("RedCloth")

--- a/lib/jsonrpc2/version.rb
+++ b/lib/jsonrpc2/version.rb
@@ -1,5 +1,5 @@
 # JSONRPC2 namespace module
 module JSONRPC2
   # Version
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
- Moved changelog into a separate file to avoid clutter
- Reformatted changelog for nicer rendering and to allow HTML anchors
- Added some metadata to gemspec
- Bumped version for release

ref: KBZ-4785
