### PR TITLE
Explicitly set the bindir to 'exe'

### DIFF
--- a/jsonrpc2.gemspec
+++ b/jsonrpc2.gemspec
@@ -45,6 +45,7 @@ EOD
   gem.summary       = %q{JSON-RPC2 server DSL}
   gem.homepage      = "http://github.com/livelink/jsonrpc2"
 
+  gem.bindir        = 'exe'
   gem.executables   = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
When trying to release the gem an error occurs:
```
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["bin/jsonrpc2"] are not files
```
Turns out, that `bin` is still a default directory for executables, so `exe` has to be set explicitly. 

---

Nice explanation from RubyGems repo
> Bundler's recommendation is to use exe/ for the executables you, as a gem author, want to expose to your users. For example, the bundler gem puts [the bundle executable inside exe/](https://github.com/rubygems/rubygems/blob/a5f5d32207aafe39ce9804a2ddfb31b27eed76d1/bundler/exe/bundle) since that's the executable bundler users will run. On the other hand, the recommendation is to use bin/ for internal executables meant to be used for internal development of your gem, but that are not supposed to be exposed to your users. For example, bundler uses [a rspec binstub inside bin/](https://github.com/rubygems/rubygems/blob/a5f5d32207aafe39ce9804a2ddfb31b27eed76d1/bundler/bin/rspec) to help running its own specs.

[Source](https://github.com/rubygems/rubygems/issues/4884#issuecomment-913045548)