### PR TITLE
Introduce ability to set up hook for request calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.0] - 2023-02-09
+### Added
+- Possibility to define callback for request calls prior to validation `JSONRPC2::Interface#before_validation`
+
 ## [0.2.0] - 2022-04-07
 ### Added
 - Possibility to define callback for server errors with `JSONRPC2::Interface#on_server_error`

--- a/lib/jsonrpc2/interface.rb
+++ b/lib/jsonrpc2/interface.rb
@@ -239,6 +239,7 @@ module JSONRPC2
     # @param [Hash] params Method parameters
     # @return [Hash] JSON response
     def call(method, id, params)
+      invoke_before_validation_hook(method, id, params)
       if api_methods.include?(method)
         begin
           Types.valid_params?(self.class, method, params)
@@ -398,8 +399,17 @@ module JSONRPC2
       log_error("Server error hook failed - #{error.class}: #{error.message} #{error.backtrace.join("\n    ")}")
     end
 
+    def invoke_before_validation_hook(method, id, params)
+      before_validation(method: method, id: id, params: params)
+    rescue Exception => error
+      log_error("Before validation hook failed - #{error.class}: #{error.message} #{error.backtrace.join("\n    ")}")
+    end
+
     # Available for reimplementation by a subclass, noop by default
     def on_server_error(request_id:, error:)
+    end
+
+    def before_validation(method:, id:, params:)
     end
 
     def log_error(message)

--- a/lib/jsonrpc2/interface.rb
+++ b/lib/jsonrpc2/interface.rb
@@ -401,7 +401,7 @@ module JSONRPC2
 
     def invoke_before_validation_hook(method, id, params)
       before_validation(method: method, id: id, params: params)
-    rescue Exception => error
+    rescue => error
       log_error("Before validation hook failed - #{error.class}: #{error.message} #{error.backtrace.join("\n    ")}")
     end
 

--- a/lib/jsonrpc2/version.rb
+++ b/lib/jsonrpc2/version.rb
@@ -1,5 +1,5 @@
 # JSONRPC2 namespace module
 module JSONRPC2
   # Version
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/lib/interface_spec.rb
+++ b/spec/lib/interface_spec.rb
@@ -118,6 +118,30 @@ RSpec.describe JSONRPC2::Interface do
           )
         end
       end
+
+      context 'with a correctly configured before_validation hook' do
+        before do
+          rpc_api_class.class_eval do
+            attr_reader :test_before_validation_data
+
+            def before_validation(method:, id:, params:)
+              @test_before_validation_data = {
+                method: method,
+                id: id,
+                params: params
+              }
+            end
+          end
+        end
+
+        it 'invokes the hook' do
+          dispatch_result
+
+          expect(instance.test_before_validation_data[:method]).to eq('hello')
+          expect(instance.test_before_validation_data[:id]).to eq(123)
+          expect(instance.test_before_validation_data[:params]).to eq({ 'name' => 'Geoff' })
+        end
+      end
     end
 
     context 'with an unhandled server error' do


### PR DESCRIPTION
**Problems**
We were looking to introduce some additional observability within our application, but the specifics of the request calls were not exposed. Leaving no clean or pleasant ways to achieve that.

**Solutions**
Introduce dedicated before_validation hook, which can be used by defining `before_validation(method:, id:, params:)` method within the JSONRPC2 API. This is invoked at the start of every `#call` action.